### PR TITLE
Fixed missing team id beacon queue

### DIFF
--- a/app/Http/Controllers/BeaconController.php
+++ b/app/Http/Controllers/BeaconController.php
@@ -10,6 +10,7 @@ use App\Setting;
 use App\Http\Requests;
 use Illuminate\Http\Request;
 use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Auth;
 
 class BeaconController extends Controller
 {
@@ -44,8 +45,7 @@ class BeaconController extends Controller
         $services = array(
             '' => 'Select Service',
             'kontakt.io' => 'Kontakt.io',
-            'estimote' => 'estimote',
-            'test' => 'test'
+            'estimote' => 'estimote'
         );
 
         return view('beacons.import', compact('services'));
@@ -69,7 +69,11 @@ class BeaconController extends Controller
 
         $service = $filtered->get('beacon-import-service');
 
-        dispatch(new ImportBeaconsJob($service));
+        $user = Auth::user();
+
+        $teamId = $user->currentTeam->id;
+
+        dispatch(new ImportBeaconsJob($service, $teamId));
 
         return redirect()->route('beacons.import');
     }

--- a/app/Http/Controllers/BlockController.php
+++ b/app/Http/Controllers/BlockController.php
@@ -43,13 +43,14 @@ class BlockController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Request $request
      * @return \Illuminate\Http\Response
      */
     public function store(Request $request)
     {
         $this->validate($request, [
-           'name' => 'required|max:255',
+            'name' => 'required|max:255',
+            'image' => 'image'
         ]);
 
         $block = Block::create($request->except('image'));
@@ -62,7 +63,7 @@ class BlockController extends Controller
     /**
      * Display the specified resource.
      *
-     * @param  int  $id
+     * @param  int $id
      * @return \Illuminate\Http\Response
      */
     public function show($id)
@@ -74,7 +75,7 @@ class BlockController extends Controller
     /**
      * Show the form for editing the specified resource.
      *
-     * @param  int  $id
+     * @param  int $id
      * @return \Illuminate\Http\Response
      */
     public function edit($id)
@@ -87,14 +88,15 @@ class BlockController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $id
+     * @param  \Illuminate\Http\Request $request
+     * @param  int $id
      * @return \Illuminate\Http\Response
      */
     public function update(Request $request, $id)
     {
         $this->validate($request, [
-           'name' => 'required|max:255',
+            'name' => 'required|max:255',
+            'image' => 'image'
         ]);
 
         $block = Block::findOrFail($id);
@@ -121,7 +123,7 @@ class BlockController extends Controller
     /**
      * Remove the specified resource from storage.
      *
-     * @param  int  $id
+     * @param  int $id
      * @return \Illuminate\Http\Response
      */
     public function destroy($id)
@@ -136,7 +138,7 @@ class BlockController extends Controller
     /**
      * Upload Image
      * @param  Block $Block
-     * @param  Request  $request
+     * @param  Request $request
      * @return void
      */
     protected function uploadIcon(Block $block, Request $request)

--- a/app/Jobs/ImportBeaconsJob.php
+++ b/app/Jobs/ImportBeaconsJob.php
@@ -15,15 +15,17 @@ class ImportBeaconsJob implements ShouldQueue
     use InteractsWithQueue, Queueable, SerializesModels;
 
     protected $service;
+    protected $teamId;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct($service)
+    public function __construct($service, $teamId)
     {
         $this->service = $service;
+        $this->teamId = $teamId;
     }
 
     /**
@@ -48,14 +50,15 @@ class ImportBeaconsJob implements ShouldQueue
                         'minor' => $device->minor,
                         'major' => $device->major,
                         'created_at' => Carbon::now()->toDateTimeString(),
-                        'updated_at' => Carbon::now()->toDateTimeString()
+                        'updated_at' => Carbon::now()->toDateTimeString(),
+                        'team_id' => $this->teamId
                     ]);
+                    echo "Beacon oprettet!";
                 } catch (\Exception $e) {
                     echo $e;
                 }
 
             } else {
-                echo "tom!";
             }
         }
 
@@ -114,7 +117,7 @@ class ImportBeaconsJob implements ShouldQueue
         ]);
 
         try {
-            $response = $client->request('GET', '/device?maxResult=5');
+            $response = $client->request('GET', '/device?maxResult=2000');
             $results = json_decode($response->getBody()->getContents());
             $devices = collect();
 

--- a/app/Place.php
+++ b/app/Place.php
@@ -18,7 +18,7 @@ class Place extends Model
      * @var array
      */
     protected $fillable = ['name', 'address', 'zipcode', 'city',
-        'identifier_one', 'identifier_one', 'identifier_three', 'identifier_four', 'identifier_five',
+        'identifier_one', 'identifier_two', 'identifier_three', 'identifier_four', 'identifier_five',
         'place_id', 'order', 'beacon_positioning_enabled', 'beacon_proximity_enabled', 'activated'];
 
     /**


### PR DESCRIPTION
Team id was missing from Beacons when running an import through the queue. This has now been fixed and the Beacon will now inherit the team id from the user initiating the queue.

An image attribute has also been added to the validator, since it was possible to upload non-images. 